### PR TITLE
Align health and readiness checks

### DIFF
--- a/plugins/v1/plugin.proto
+++ b/plugins/v1/plugin.proto
@@ -52,11 +52,6 @@ message HTTPResponse {
   bool continue = 4;  // If true, continue to next plugin/handler; if false, short-circuit
 }
 
-// Ready status response.
-message ReadyResponse {
-  bool ready = 1;
-}
-
 // TelemetryConfig provides OpenTelemetry configuration.
 message TelemetryConfig {
   string otlp_endpoint = 1;
@@ -82,9 +77,9 @@ service Plugin {
   rpc GetCapabilities(google.protobuf.Empty) returns (Capabilities);
 
   // Health / readiness
-  // Returns error via gRPC status if unhealthy
-  rpc Health(google.protobuf.Empty) returns (google.protobuf.Empty);
-  rpc Ready(google.protobuf.Empty) returns (ReadyResponse);
+  // Returns error via gRPC status if unhealthy or not ready.
+  rpc CheckHealth(google.protobuf.Empty) returns (google.protobuf.Empty);
+  rpc CheckReady(google.protobuf.Empty) returns (google.protobuf.Empty);
 
   // Request / response handling
   rpc HandleRequest(HTTPRequest) returns (HTTPResponse);


### PR DESCRIPTION
## Summary

* Rename `Health` -> `CheckHealth` and `Ready` -> `CheckReady` for consistent verb-based naming
* Use `Empty` return type for both methods instead of `ReadyResponse`
* Remove `ReadyResponse` message (no longer needed)

Both methods now use gRPC status codes to indicate health/readiness state, simplifying the API for plugin developers.

## Changes

* `Health()` -> `CheckHealth()`
* `Ready()` -> `CheckReady()` 
* Return type: `ReadyResponse` -> `google.protobuf.Empty`
* Removed: `ReadyResponse` message definition

This aligns with gRPC best practices for health/readiness checks.