### PR TITLE
Fix Go package name in proto go_package option

### DIFF
--- a/plugins/v1/plugin.proto
+++ b/plugins/v1/plugin.proto
@@ -4,7 +4,7 @@ package mozilla.mcpd.plugins.v1;
 
 // Go Option: This option tells the Go compiler where to find the generated code.
 // This is what plugin developers writing in Go will reference.
-option go_package = "github.com/mozilla-ai/mcpd-plugins-sdk-go/pkg/plugins/v1;v1";
+option go_package = "github.com/mozilla-ai/mcpd-plugins-sdk-go/pkg/plugins/v1;mcpdpluginsv1";
 
 // C# Option: Defines the namespace for the generated classes.
 // This is the namespace developers using the C# plugin SDK will reference.


### PR DESCRIPTION
## Summary
- Changes the Go package name in `go_package` option from `v1` to `mcpdpluginsv1`
- The import path remains unchanged (`pkg/plugins/v1`)
- This fixes pkg.go.dev displaying the package as "v1" instead of a meaningful name

## Downstream impact
After this is released (as v0.1.0), the following repos need to update their proto version pin and regenerate:
- mcpd-plugins-sdk-go (breaking: will also restructure directories)
- mcpd-plugins-sdk-rust (cosmetic: go_package irrelevant to Rust)
- mcpd-plugins-sdk-dotnet (cosmetic: csharp_namespace unchanged)
- mcpd-plugins-sdk-python (cosmetic: embedded descriptor changes, no functional impact)

## Test plan
- [x] Verified the only change is the package name portion of go_package
- [ ] Review proto file change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SDK package configuration to improve the import path structure for Go developers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->